### PR TITLE
Remove newlines from repo descriptions

### DIFF
--- a/starred.py
+++ b/starred.py
@@ -45,7 +45,7 @@ def starred(username, sort, token):
 
     for s in stars:
         language = s.language or 'Others'
-        description = html_escape(s.description) if s.description else ''
+        description = html_escape(s.description).replace('\n', '') if s.description else ''
 
         if language not in repo_dict:
             repo_dict[language] = []


### PR DESCRIPTION
This fixes the markdown formatting breaking when a repo has a newline in its description like this one: https://github.com/facebook/PathPicker