### PR TITLE
Fix key for language which is more than one word

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-click==6.6
+click==6.7
 github3.py==1.0.0a4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     py_modules=['starred'],
     platforms='any',
     install_requires=[
-        'click==6.6',
+        'click==6.7',
         'github3.py==1.0.0a4',
     ],
     entry_points={

--- a/starred.py
+++ b/starred.py
@@ -78,7 +78,7 @@ def starred(username, token, sort, repository, message):
         repo_dict = OrderedDict(sorted(repo_dict.items(), key=lambda l: l[0]))
 
     for language in repo_dict.keys():
-        data = u'  - [{}](#{})'.format(language, language.lower())
+        data = u'  - [{}](#{})'.format(language, '-'.join(language.lower().split()))
         click.echo(data)
     click.echo('')
 


### PR DESCRIPTION
The key generated for language with more than one word, such as `Common Lisp` is `common-lisp`, not just `common lisp`.